### PR TITLE
Add version info to the sysupdate-dbus docs

### DIFF
--- a/man/systemd-sysupdate.xml
+++ b/man/systemd-sysupdate.xml
@@ -300,7 +300,9 @@
 
         <listitem><para>Prevents fetching metadata from the network (i.e. SHA256SUMS). This is most useful
         when used in combination with the <command>list</command> command, to query locally installed
-        versions.</para></listitem>
+        versions.</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
       </varlistentry>
 
       <xi:include href="standard-options.xml" xpointer="no-pager" />

--- a/man/sysupdate.d.xml
+++ b/man/sysupdate.d.xml
@@ -499,7 +499,9 @@
 
         <para>This setting supports specifier expansion. See below for details on supported
         specifiers. This setting will also expand the <literal>@v</literal> wildcard pattern. See above
-        for details.</para></listitem>
+        for details.</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
       </varlistentry>
 
       <varlistentry>
@@ -516,7 +518,9 @@
         can include this setting.</para>
 
         <para>This setting supports specifier expansion. See below for details on supported
-        specifiers.</para></listitem>
+        specifiers.</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
       </varlistentry>
     </variablelist>
   </refsect1>

--- a/man/updatectl.xml
+++ b/man/updatectl.xml
@@ -55,7 +55,9 @@
         specified target. If a <replaceable>VERSION</replaceable> is specified, this command
         lists all known information about the specific version.</para>
 
-        <para>See the example below for details of the output.</para></listitem>
+        <para>See the example below for details of the output.</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
       </varlistentry>
 
       <varlistentry>
@@ -64,7 +66,9 @@
         <listitem><para>Check if any updates are available for the specified targets. If no targets
         are specified, all available targets will be checked for updates.</para>
 
-        <para>See the example below for details of the output.</para></listitem>
+        <para>See the example below for details of the output.</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
       </varlistentry>
 
       <varlistentry>
@@ -72,14 +76,18 @@
 
         <listitem><para>Update the specified targets to the specified versions. If a target
         is specified without a version, then it will be updated to the latest version. If no targets are
-        specified, then all available targets will be updated to the latest version.</para></listitem>
+        specified, then all available targets will be updated to the latest version.</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
       </varlistentry>
 
       <varlistentry>
         <term><command>vacuum</command> [<replaceable>TARGET</replaceable>…]</term>
 
         <listitem><para>Clean up old versions of the specified targets. If no targets are specified,
-        all available targets will be vacuumed.</para></listitem>
+        all available targets will be vacuumed.</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
       </varlistentry>
 
       <xi:include href="standard-options.xml" xpointer="help" />
@@ -97,7 +105,9 @@
         <term><option>--reboot</option></term>
 
         <listitem><para>When used with the <command>update</command> command, reboots the system
-        after updates finish applying. If any update fails, the system will not reboot.</para></listitem>
+        after updates finish applying. If any update fails, the system will not reboot.</para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
       </varlistentry>
 
       <varlistentry>
@@ -106,7 +116,9 @@
         <listitem><para>When used with the <command>list</command> command, disables fetching
         metadata from the network. This makes the <command>list</command> command only return
         information that is available locally (i.e. about versions already installed on the system).
-        </para></listitem>
+        </para>
+
+        <xi:include href="version-info.xml" xpointer="v256"/></listitem>
       </varlistentry>
 
       <xi:include href="user-system-options.xml" xpointer="host" />


### PR DESCRIPTION
There are two upstream test failures in https://github.com/systemd/systemd/pull/32363:
```
1181/1874 systemd:dist / dbus-docs-fresh                                                    FAIL             2.88s   exit status 1
1193/1874 systemd:dist / check-version-history                                              FAIL             1.17s   exit status 1
```

Based on the error messages in the CI, we are supposed to provide the version info. in the docs:
```
 1181/1874 systemd:dist / dbus-docs-fresh                                                    FAIL             2.88s   exit status 1
>>> UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MALLOC_PERTURB_=65 LD_LIBRARY_PATH=/home/runner/work/systemd/systemd/build/src/shared:/home/runner/work/systemd/systemd/build/src/core ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 /home/runner/work/systemd/systemd/tools/update-dbus-docs.py --build-dir /home/runner/work/systemd/systemd/build --test /home/runner/work/systemd/systemd/build/../man/org.freedesktop.LogControl1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.home1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.hostname1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.import1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.locale1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.login1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.machine1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.network1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.oom1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.portable1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.resolve1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.systemd1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.sysupdate1.xml /home/runner/work/systemd/systemd/build/../man/org.freedesktop.timedate1.xml
――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――
Missing version information for org.freedesktop.sysupdate1.Manager.ListTargets()
Missing version information for org.freedesktop.sysupdate1.Manager.ListJobs()
Missing version information for org.freedesktop.sysupdate1.Manager.ListAppstream()
Missing version information for org.freedesktop.sysupdate1.Manager.JobRemoved()
Missing version information for org.freedesktop.sysupdate1.Target.List()
Missing version information for org.freedesktop.sysupdate1.Target.Describe()
Missing version information for org.freedesktop.sysupdate1.Target.CheckNew()
Missing version information for org.freedesktop.sysupdate1.Target.Update()
Missing version information for org.freedesktop.sysupdate1.Target.Vacuum()
Missing version information for org.freedesktop.sysupdate1.Target.Class
Missing version information for org.freedesktop.sysupdate1.Target.Name
Missing version information for org.freedesktop.sysupdate1.Target.Path
Missing version information for org.freedesktop.sysupdate1.Target.Version
Missing version information for org.freedesktop.sysupdate1.Target.Appstream
Missing version information for org.freedesktop.sysupdate1.Job.Cancel()
Missing version information for org.freedesktop.sysupdate1.Job.Id
Missing version information for org.freedesktop.sysupdate1.Job.Type
Missing version information for org.freedesktop.sysupdate1.Job.Offline
Missing version information for org.freedesktop.sysupdate1.Job.Progress
```

* Cannot really setup the build environment to reproduce the failures locally.
